### PR TITLE
Add pre-commit (changed to prek)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -53,7 +53,7 @@ jobs:
         cd ../..
     - name: Upload documentation as an artifact
       uses: actions/upload-artifact@v4
-      with: 
+      with:
         name: html-documentation
         retention-days: 15
         path: |

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,4 +1,4 @@
-name: "RUFF"
+name: PREK
 
 on:
   push:
@@ -9,29 +9,8 @@ on:
       - "*"
 
 jobs:
-  ruff:
-
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.12]
-
+  prek:
+    runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install nose nose-exclude coverage coveralls ruff
-        pip install --progress-bar off .
-    - name: Lint with Ruff
-      run: |
-        ruff check --diff caravel
+      - uses: actions/checkout@v6
+      - uses: j178/prek-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 *.log
 *~
 .coverage
-.*
 
 # Folders #
 ###########

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: mixed-line-ending
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.4
+    hooks:
+      - id: ruff-check
+        args: ["--fix", "--show-fixes"]

--- a/caravel/utils.py
+++ b/caravel/utils.py
@@ -71,7 +71,7 @@ def get_logs_to_remove(log_dir, cut_date=None):
         path to the directory to clean.
     cut_date: str or None
         date from before which files are returned. If None,
-        return files than are older than one year old.  
+        return files than are older than one year old.
         Should be formatted %Y-%m-%d (e.g. 2024-08-06).
     """
 
@@ -99,14 +99,14 @@ def get_logs_to_remove(log_dir, cut_date=None):
 
 def clean_logs_dir(log_dir, cut_date=None):
     """ Remove all files that are older than cut_date.
-    
+
     Parameters
     ----------
     log_dir: str
         path to the directory to clean.
     cut_date:
         date from before which files are suppressed. If None,
-        remove files than are older than one year old.  
+        remove files than are older than one year old.
         Should be formatted %Y-%m-%d (e.g. 2024-08-06).
     """
 

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -6,4 +6,3 @@ pycaravel usage examples
 .. contents:: **Contents**
     :local:
     :depth: 1
-

--- a/examples/conf/hbn_derivatives.conf
+++ b/examples/conf/hbn_derivatives.conf
@@ -4,12 +4,12 @@
         {
             "name": "process",
             "pattern": "derivatives/([a-zA-Z0-9_]*)",
-            "directory": "{process}"            
+            "directory": "{process}"
         },
         {
             "name": "subject",
             "pattern": ".*sub-([a-zA-Z0-9]+)",
-            "directory": "{process}/{subject}"            
+            "directory": "{process}/{subject}"
         },
         {
             "name": "session",


### PR DESCRIPTION
- assorted pre-commit hooks
- ruff linter

Depends on #15 and #24.

You will have to enable pre-commit for this repository: **Settings** > **GitHub_Apps**.

![Settings_GitHub_Apps](https://github.com/user-attachments/assets/e390f1c7-3ff7-4a1e-8070-49db88c8cff8)

**EDIT:** Let's use [prek](https://prek.j178.dev/) instead of pre-commit. It hasn't gained as much traction as pre-commit yet, but it is a drop-in replacement for pre-commit and can be run in GitHub Actions via the [j178/prek-action](https://github.com/j178/prek-action) repository.