### PR TITLE
Ag change layout setup

### DIFF
--- a/caravel/scripts/project-ci
+++ b/caravel/scripts/project-ci
@@ -12,6 +12,7 @@ import os
 import re
 import json
 import shutil
+import glob
 import inspect
 import logging
 import importlib
@@ -143,10 +144,14 @@ def main(project, upload_mounts, allowed_subjects, working_dir, nextcloud_url,
     if verbose > 0:
         validation_module.ValidationBase.__level__ = "debug"
     validation_module.ValidationBase.setup_logging(logfile=logfile)
+    # set up (= empty) layout folder
     layoutdir = os.path.join(working_dir, "layout")
     if os.path.isdir(layoutdir):
-        shutil.rmtree(layoutdir)
-    os.mkdir(layoutdir)
+        for path in glob.glob(layoutdir+'/*'):
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+            if os.path.isfile(path):
+                os.remove(path)
     datadir = os.path.join(working_dir, "data")
     if not os.path.isdir(datadir):
         os.mkdir(datadir)


### PR DESCRIPTION
The layout removal and recreation cause issue when running several integration instances at the same time (like when using a crontab). It is modified only to empy the file, not to remove and recreate it.

This PR is built from the clean logs PR (PR #23)