### PR TITLE
Test Python 3.12

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: ["3.8", "3.12"]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
In addition to Python 3.8

We cannot support Python 3.13 until this _cffi_ issue is fixed:
https://github.com/python-cffi/cffi/pull/24