### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm"]
+requires = ["setuptools>=77.0.3", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,7 +9,7 @@ requires-python = ">=3.8"
 authors = [
     {name = "pycaravel developers", email = "antoine.grigis@cea.fr"},
 ]
-license = {text = "CeCILL-B"}
+license = "CECILL-B"
 classifiers = [
     "Development Status :: 1 - Planning",
     "Environment :: Console",


### PR DESCRIPTION
Declare licenses using only these two fields, as per PEP 639:
* `license`:       SPDX license expression consisting of one or more license identifiers
* `license-files`: list of license file glob patterns

Supported by setuptools ≥ 77.0, or perhaps setuptools ≥ 77.0.3 which irons out some bugs:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files